### PR TITLE
replaced monitoring-server with monitoring_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,17 +107,17 @@ cd FreeTON-Rust-Node
 ```
 2. Configure variables in ansible/group_vars (refer to Variables section)
 3. Configure hosts file. Put public IP address under rustnode and optionally under monitoring server section. Examples:
-    1. Example hosts file if running Rust node and monitoring-server remotely:
+    1. Example hosts file if running Rust node and monitoring_server remotely:
     ```
-    [monitoring-server]
+    [monitoring_server]
     64.221.146.31
     
     [rustnode]
     131.11.89.30
     ```
-    2. Example hosts file if running Rust node locally with remote monitoring-server:
+    2. Example hosts file if running Rust node locally with remote monitoring_server:
     ```
-    [monitoring-server]
+    [monitoring_server]
     64.221.146.31 
     
     [rustnode]
@@ -125,7 +125,7 @@ cd FreeTON-Rust-Node
     ```
     3. Example hosts file if running Rust node and monitoring server locally (**not recommended**):
     ```
-    [monitoring-server]
+    [monitoring_server]
     131.11.89.30 ansible_connection=local
     
     [rustnode]
@@ -133,7 +133,7 @@ cd FreeTON-Rust-Node
     ```
     4. Example hosts file if running only Rust node locally (don't forget do disable remote logging in variables section):
     ```
-    [monitoring-server]
+    [monitoring_server]
     
     [rustnode]
     131.11.89.30 ansible_connection=local
@@ -155,7 +155,7 @@ ansible-playbook -i hosts -u ubuntu --become --become-method=sudo --ask-become-p
 ansible-playbook -i hosts -u ubuntu --become --become-method=sudo --ask-become-pass --private-key <keypath> --tags upgrade ansible/rustonde.yml
 
 # Monitoring server
-ansible-playbook -i hosts -u ubuntu --become --become-method=sudo --ask-become-pass --private-key <keypath> --tags install ansible/monitoring-server.yml
+ansible-playbook -i hosts -u ubuntu --become --become-method=sudo --ask-become-pass --private-key <keypath> --tags install ansible/monitoring_server.yml
 ``` 
 
 ## Variables
@@ -208,11 +208,11 @@ Monitoring server installation includes metrics and logs aggregation, parsing, v
 
 Each component of the monitoring system have an info/view panel, which can be accessible using the following URLs:
 
-* **Grafana** - http://[monitoring-server-ip]:3000/
-* **Prometheus** - http://[monitoring-server-ip]:9090/
-* **Loki** - http://[monitoring-server-ip]:3100/
-* **Promtail** - http://[monitoring-server-ip]:9080/
-* **Alertmanager** - http://[monitoring-server-ip]:9090/
+* **Grafana** - http://[monitoring_server_ip]:3000/
+* **Prometheus** - http://[monitoring_server_ip]:9090/
+* **Loki** - http://[monitoring_server_ip]:3100/
+* **Promtail** - http://[monitoring_server_ip]:9080/
+* **Alertmanager** - http://[monitoring_server_ip]:9090/
 
 Default credentials should be configured in group_vars/monitoring_server variables file.
 

--- a/ansible/group_vars/rustnode
+++ b/ansible/group_vars/rustnode
@@ -1,5 +1,5 @@
 
-# if true - all bins will be built remotely. If false - downloaded from Github releases. 
+# if true - all bins will be built remotely. If false - downloaded from Github releases.
 build: false
 
 # this section is required in case of build:false
@@ -71,7 +71,7 @@ config_abi_depool_helper_url: "https://raw.githubusercontent.com/tonlabs/ton-lab
 # DEV NET ADDRS
 #msig_addr: "12658a2ea3dc3fe0ad34de2a8c364568adb4a01c8ee8e2dc08779afabd502816"     # !!! without WC. MSIG should be deployed to both 0 and -1 if validator:single. To 0 only if validator:depool.
 #elector_addr: "3333333333333333333333333333333333333333333333333333333333333333"  # !!! without WC. Used if validator:depool. Deployed to -1.
-#depool_addr: "edd4f0dbf5d4181599e31690468689bc3d8bab4ce082aeb5b78f1fd08809366a"   # !!! without WC. Used if validator:depool. Depool should be deployed to 0. 
+#depool_addr: "edd4f0dbf5d4181599e31690468689bc3d8bab4ce082aeb5b78f1fd08809366a"   # !!! without WC. Used if validator:depool. Depool should be deployed to 0.
 #helper_addr: "16e11bf2bd853841be8eebbbae3b7e7599d9e5b2aee879cd9468477c89373f16"   # !!! without WC. Used if validator:depool. Depool helper should be deployed to 0.
 
 # RUST NET ADDRS | DEPOOL 01
@@ -83,16 +83,16 @@ helper_addr: "8531841c073538f501a2543e1b197f4c0d5431f2f279dd22d294d2314db1efd2" 
 # RUST NET ADDRS | DEPOOL 02
 #msig_addr: "4000610da7d7f89b92cd64212e5b983d9ccac9938333174f352a5b3c416997c4"     # !!! without WC. MSIG should be deployed to both 0 and -1 if validator:single. To 0 only if validator:depool.
 #elector_addr: "3333333333333333333333333333333333333333333333333333333333333333"  # !!! without WC. Used if validator:depool. Deployed to -1.
-#depool_addr: "8fba61cbf5df181736bf41640217dee4eef453d7dc0b2c0a095a5590ffa2c225"   # !!! without WC. Used if validator:depool. Depool should be deployed to 0. 
+#depool_addr: "8fba61cbf5df181736bf41640217dee4eef453d7dc0b2c0a095a5590ffa2c225"   # !!! without WC. Used if validator:depool. Depool should be deployed to 0.
 #helper_addr: "31b2f1c4c2c889d1b9b4586c36a1ed8fc153b154ac63c35676b7f2a1dfa516e4"   # !!! without WC. Used if validator:depool. Depool helper should be deployed to 0.
 
 # Logging configuration section
 logging:
   rustnode:
     remote:
-      enabled: false                            # if true, will send logs to monitoring server specified in hosts file [monitoring-server], false - to node file system.
+      enabled: false                            # if true, will send logs to monitoring server specified in hosts file [monitoring_server], false - to node file system.
     level:
       root: debug                               # possible error warn info debug trace off
   validator:
     remote:
-      enabled: false                            # if true, will send logs to monitoring server specified in hosts file [monitoring-server], false - node to file system.
+      enabled: false                            # if true, will send logs to monitoring server specified in hosts file [monitoring_server], false - node to file system.

--- a/ansible/monitoring-server.yml
+++ b/ansible/monitoring-server.yml
@@ -1,5 +1,5 @@
 ---
-- name: monitoring-server
-  hosts: monitoring-server
+- name: monitoring_server
+  hosts: monitoring_server
   roles:
-    - monitoring-server
+    - monitoring_server

--- a/ansible/roles/rustnode/templates/rustnode.service.j2
+++ b/ansible/roles/rustnode/templates/rustnode.service.j2
@@ -8,7 +8,7 @@ LimitNOFILE=1024000
 LimitNOFILESoft=1024000
 User=rustnode
 Type=simple
-ExecStart=/bin/bash -c "/usr/local/bin/ton_node --configs {{ rustnode_conf_dir }} --ckey \"$(cat "{{ rustnode_conf_dir }}/console.pub")\" {% if logging.rustnode.remote.enabled %} | /usr/bin/logger -n {{ logging.rustnode.remote.addr | default(hostvars[groups['monitoring-server'][0]]['inventory_hostname']) }} -P 1514 -T --rfc5424 --octet-count{% endif %}"
+ExecStart=/bin/bash -c "/usr/local/bin/ton_node --configs {{ rustnode_conf_dir }} --ckey \"$(cat "{{ rustnode_conf_dir }}/console.pub")\" {% if logging.rustnode.remote.enabled %} | /usr/bin/logger -n {{ logging.rustnode.remote.addr | default(hostvars[groups['monitoring_server'][0]]['inventory_hostname']) }} -P 1514 -T --rfc5424 --octet-count{% endif %}"
 Restart=on-failure
 
 [Install]

--- a/ansible/roles/rustvalidator/templates/rustvalidator.service.j2
+++ b/ansible/roles/rustvalidator/templates/rustvalidator.service.j2
@@ -19,7 +19,7 @@ Environment="TONOSCLI_CONFIG={{ rustvalidator_conf_dir }}/tonos-cli.conf.json"
 
 User=rustvalidator
 Type=simple
-ExecStart=/bin/bash -c "/usr/bin/python3   {{ scripts_dir }}/validator.py {% if logging.validator.remote.enabled %} | /usr/bin/logger -n {{ logging.validator.remote.addr | default(hostvars[groups['monitoring-server'][0]]['inventory_hostname']) }} -P 1514 -T --rfc5424 --octet-count{% endif %}"
+ExecStart=/bin/bash -c "/usr/bin/python3   {{ scripts_dir }}/validator.py {% if logging.validator.remote.enabled %} | /usr/bin/logger -n {{ logging.validator.remote.addr | default(hostvars[groups['monitoring_server'][0]]['inventory_hostname']) }} -P 1514 -T --rfc5424 --octet-count{% endif %}"
 Restart=on-failure
 
 [Install]

--- a/hosts
+++ b/hosts
@@ -1,3 +1,3 @@
-[monitoring-server]
+[monitoring_server]
 
 [rustnode]

--- a/start.sh
+++ b/start.sh
@@ -9,7 +9,7 @@ else
 
   username=$2
   action=$4
-  
+
   if python -mplatform|grep "Ubuntu"
     then
      echo "OS is Ubuntu"
@@ -25,7 +25,7 @@ else
           echo "\nFor run this playbook you need Ansible"
           exit 1
        fi
-    fi  
+    fi
   else
     echo "OS is not supported"
   fi
@@ -40,13 +40,13 @@ else
             break
   	    ;;
           "Monitoring Server")
-            yml="monitoring-server"
+            yml="monitoring_server"
   	    break
   	    ;;
           *) echo "invalid option $REPLY";;
       esac
   done
-  
+
   export ANSIBLE_HOST_KEY_CHECKING=False
   echo 'Please enter connection method: '
   options=("SSH key" "SSH password")


### PR DESCRIPTION
This is to avoid `[WARNING]: Invalid characters were found in group names but not replaced`
as only valid python identifiers are allowed since v2.8:
https://github.com/ansible/ansible/issues/56930#issuecomment-497763071
